### PR TITLE
Copy transformations to @reducedDims when possible

### DIFF
--- a/R/CoreMethods.R
+++ b/R/CoreMethods.R
@@ -407,7 +407,7 @@ sc3_calc_transfs.SingleCellExperiment <- function(object) {
 
     # put a copy of transformations to @reducedDims when applicable
     if (nrow(transfs[[1]]) == ncol(sce)) {
-        reducedDims(object) <- transformations
+        reducedDims(object) <- SimpleList(transformations)
     }
     return(object)
 }

--- a/R/CoreMethods.R
+++ b/R/CoreMethods.R
@@ -404,6 +404,11 @@ sc3_calc_transfs.SingleCellExperiment <- function(object) {
     metadata(object)$sc3$transformations <- transfs
     # remove distances after calculating transformations
     metadata(object)$sc3$distances <- NULL
+
+    # put a copy of transformations to @reducedDims when applicable
+    if (nrow(transfs[[1]]) == ncol(sce)) {
+        reducedDims(object) <- transformations
+    }
     return(object)
 }
 

--- a/R/CoreMethods.R
+++ b/R/CoreMethods.R
@@ -406,7 +406,7 @@ sc3_calc_transfs.SingleCellExperiment <- function(object) {
     metadata(object)$sc3$distances <- NULL
 
     # put a copy of transformations to @reducedDims when applicable
-    if (nrow(transfs[[1]]) == ncol(sce)) {
+    if (nrow(transfs[[1]]) == ncol(object)) {
         reducedDims(object) <- SimpleList(transformations)
     }
     return(object)


### PR DESCRIPTION
This PR modifies sc3_calc_transfs() to put a copy of `@metadata$sc3$transformations` to `@reducedDims` when dimensions fit, to expose useful intermediate results for potential use by other programmes consuming `SingleCellExperiment`.